### PR TITLE
Allow to patch AEgir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 aegir formula
 =============
 
+0.0.4 (2018-08-17)
+
+- Add a state to patch AEgir's installations
+
 0.0.3 (2018-07-31)
 
 - Add service management for hosting-queued

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,13 @@ Installs extra modules for `aegir`.
 
 See ``pillar.example`` file for details.
 
+``aegir.patches``
+-----------------
+
+Applies patches to an existing `aegir` installation.
+
+See ``pillar.example`` file for details on accepted parameters.
+
 ``aegir.service``
 -----------------
 

--- a/aegir/defaults.yaml
+++ b/aegir/defaults.yaml
@@ -19,4 +19,5 @@ aegir:
     service: hosting-queued
     webserver: apache2
     modules: {}
+    patches: {}
 

--- a/aegir/init.sls
+++ b/aegir/init.sls
@@ -6,4 +6,5 @@ include:
   - aegir.user
   - aegir.install
   - aegir.modules
+  - aegir.patches
   - aegir.service

--- a/aegir/patches.sls
+++ b/aegir/patches.sls
@@ -1,0 +1,11 @@
+{% from "aegir/map.jinja" import aegir with context %}
+
+{% set patches = aegir.hostmaster.patches %}
+
+{% for patch, params in patches.items() %}
+aegir_apply_patch_{{ patch }}:
+  cmd.run:
+    - name: /usr/bin/curl {{ params.source }} | /usr/bin/patch {{ params.args | default('') }}
+    - cwd: {{ params.path | default('/') }}
+    - unless: {{ params.verification }}
+{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -46,3 +46,24 @@ aegir:
       hosting_clone: {}
       hosting_http_basic_auth: {}
       hosting_https: {}
+    patches:
+      letsencrypt_context:
+        path: /var/aegir/hostmaster-7.x-3.151/profiles/hostmaster/modules/aegir/hosting_https
+        source: https://www.drupal.org/files/issues/2018-07-31/wrong_letsencrypt_context_properties-2988639-4.patch
+        args: '-p1'
+        verification: test $(sha256sum /var/aegir/hostmaster-7.x-3.151/profiles/hostmaster/modules/aegir/hosting_https/submodules/letsencrypt/drush/Provision/Service/Certificate/LetsEncrypt.php |cut -f 1 -d ' ' ) = '21faeacdc0d84c011d7d77a4730ffd6f48f49a27695de784e98640f81e654e97'
+      letsencrypt_permissions:
+        path: /var/aegir/hostmaster-7.x-3.151/profiles/hostmaster/modules/aegir/hosting_https
+        source: https://www.drupal.org/files/issues/2018-03-24/2952573-hook-permissions_2.patch
+        args: '-p1'
+        verification: test $(sha256sum /var/aegir/hostmaster-7.x-3.151/profiles/hostmaster/modules/aegir/hosting_https/submodules/letsencrypt/drush/Provision/Service/Certificate/LetsEncrypt.php |cut -f 1 -d ' ' ) = '21faeacdc0d84c011d7d77a4730ffd6f48f49a27695de784e98640f81e654e97'
+      provision_drupal_settings_6:
+        path: /usr/share/drush/commands/provision
+        source: https://cgit.drupalcode.org/provision/patch/?id=7bf972c539d1ccbec79e8faa727a123553ad7cd8
+        args: '-p1'
+        verification: test $(sha256sum /usr/share/drush/commands/provision/Provision/Config/Drupal/provision_drupal_settings_6.tpl.php |cut -f 1 -d ' ' ) = '5f6a45bab4d8ec97d113734fb65bd654ad2a177d23f72ecc9f6cb91ab991e9c0'
+      provision_drupal_settings_7:
+        path: /usr/share/drush/commands/provision
+        source: https://cgit.drupalcode.org/provision/patch/?id=9f909617352a98f91358fdda80fb24e12b5a803d
+        args: '-p1'
+        verification: test $(sha256sum /usr/share/drush/commands/provision/Provision/Config/Drupal/provision_drupal_settings_7.tpl.php |cut -f 1 -d ' ' ) = '4c5a0f2c59ba43ac49d60c1872e69824806a9aca61af33620923458a929f7082'

--- a/test/integration/default/patches.rb
+++ b/test/integration/default/patches.rb
@@ -1,0 +1,28 @@
+patched_files = {
+  letsencrypt_context: [
+    '/var/aegir/hostmaster-7.x-3.151/profiles/hostmaster/modules/aegir/hosting_https/submodules/letsencrypt/drush/Provision/Service/Certificate/LetsEncrypt.php',
+    '21faeacdc0d84c011d7d77a4730ffd6f48f49a27695de784e98640f81e654e97'
+  ],
+  letsencrypt_permissions: [
+    '/var/aegir/hostmaster-7.x-3.151/profiles/hostmaster/modules/aegir/hosting_https/submodules/letsencrypt/drush/Provision/Service/Certificate/LetsEncrypt.php',
+    '21faeacdc0d84c011d7d77a4730ffd6f48f49a27695de784e98640f81e654e97'
+  ],
+  provision_drupal_settings_6: [
+    '/usr/share/drush/commands/provision/Provision/Config/Drupal/provision_drupal_settings_6.tpl.php',
+    '5f6a45bab4d8ec97d113734fb65bd654ad2a177d23f72ecc9f6cb91ab991e9c0'
+  ],
+  provision_drupal_settings_7: [
+    '/usr/share/drush/commands/provision/Provision/Config/Drupal/provision_drupal_settings_7.tpl.php',
+    '4c5a0f2c59ba43ac49d60c1872e69824806a9aca61af33620923458a929f7082'
+  ]
+}
+
+control 'Patched files' do
+  title 'should have correct hashes'
+
+  patched_files.each do |p|
+    describe file(p[1]) do
+      its('sha256sum') { should eq p[2] }
+    end
+  end
+end


### PR DESCRIPTION
AEgir/drupal uses patches to fix pre-release issues, so I added a way to 'easily' add patches to the existing AEgir installation.

Considered using [file.patch](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.file.html#salt.states.file.patch), but it support applying single patches to single files, and it's a problem when applying multiple non-sequential patches to a single file or a single patch which modifies multiple files, so I went with a `cmd.run` loop that downloads the patch and apply it. Also, the verifying criteria is configurable.